### PR TITLE
disable boost filesystem on Windows

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -132,7 +132,7 @@ jobs:
           brew install tbb
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: "6.4.2"
       - name: Checkout
@@ -219,7 +219,7 @@ jobs:
           brew install tbb
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: "6.4.2"
       - name: Checkout
@@ -797,7 +797,7 @@ jobs:
           python %GITHUB_WORKSPACE%/tools/update_version/update_version.py
 
       - name: Install Qt 5.15.2
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: "5.15.2"
           host: "windows"
@@ -911,7 +911,7 @@ jobs:
         uses: microsoft/setup-msbuild@v2
 
       - name: Install Qt 6.7.1
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           version: "6.7.1"
           host: "windows"

--- a/modules/commons/src/include/FileSystemWrapper.hpp
+++ b/modules/commons/src/include/FileSystemWrapper.hpp
@@ -10,7 +10,7 @@
 #pragma once
 //=============================================================================
 #ifdef _MSC_VER
-#define _WITH_BOOST_FILESYSTEM_
+// #define _WITH_BOOST_FILESYSTEM_
 #pragma warning(disable : 4251)
 #else
 #undef _WITH_BOOST_FILESYSTEM_


### PR DESCRIPTION
no more required to use boost filesystem