### PR TITLE
Fix code scanning alert no. 2328: Potentially overrunning write

### DIFF
--- a/modules/f2c/src/c/libf2c/endfile.c
+++ b/modules/f2c/src/c/libf2c/endfile.c
@@ -49,7 +49,7 @@ alist* a;
     b = &f__units[a->aunit];
     if (b->ufd == NULL) {
         char nbuf[10];
-        sprintf(nbuf, "fort.%ld", (long)a->aunit);
+        snprintf(nbuf, sizeof(nbuf), "fort.%ld", (long)a->aunit);
         if (tf = FOPEN(nbuf, f__w_mode[0])) {
             fclose(tf);
         }


### PR DESCRIPTION
Fixes [https://github.com/nelson-lang/nelson/security/code-scanning/2328](https://github.com/nelson-lang/nelson/security/code-scanning/2328)

To fix the buffer overflow issue, we should replace the `sprintf` function with `snprintf`, which allows us to specify the maximum number of characters to write to the buffer. This ensures that the buffer is not overrun, even if the formatted string is longer than the buffer size.

- Change the call to `sprintf` on line 52 to `snprintf`.
- Specify the size of the buffer (`sizeof(nbuf)`) as the maximum number of characters to write.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
