### PR TITLE
Fix code scanning alert no. 2327: Potentially uninitialized local variable

### DIFF
--- a/modules/f2c/src/c/libf2c/endfile.c
+++ b/modules/f2c/src/c/libf2c/endfile.c
@@ -93,7 +93,7 @@ alist* a;
 {
     OFF_T loc, len;
     unit* b;
-    int rc;
+    int rc = 0;
     FILE* bf;
 #ifdef NO_TRUNCATE
     FILE* tf;


### PR DESCRIPTION
Fixes [https://github.com/nelson-lang/nelson/security/code-scanning/2327](https://github.com/nelson-lang/nelson/security/code-scanning/2327)

To fix the problem, we need to ensure that `rc` is always initialized before it is used. The best way to fix this without changing existing functionality is to initialize `rc` to a default value at the point of its declaration. This ensures that `rc` has a defined value even if no other assignment occurs before its usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
