### PR TITLE
feat(table): Fix #1290 - Add VariableTypes property support for table objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#1288](http://github.com/nelson-lang/nelson/issues/1288) `mustBeMatrix`, `mustBeRow`, `mustBeColumn` validator functions.
 - `join`: Combine strings.
 - [#1292](http://github.com/nelson-lang/nelson/issues/1292) Large Table Display.
+- [#1290](http://github.com/nelson-lang/nelson/issues/1290) `VariableTypes` property for table: Specify the data types of table in Nelson.
 
 ### Changed
 

--- a/modules/table/functions/@table/binaryFunctionTableHelper.m
+++ b/modules/table/functions/@table/binaryFunctionTableHelper.m
@@ -30,7 +30,8 @@ function R = funTableTable(A, B, fun)
   end
   try
     for k = 1:size(R, 2)
-      R{:, k} = fun(A{:, k}, B{:, k}); 
+      R{:, k} = fun(A{:, k}, B{:, k});
+      R.Properties.VariableTypes(k) = class(R{:, k});      
     end
   catch
     functionName = func2str(fun);
@@ -58,6 +59,7 @@ function R = funArrayTable(A, B, fun)
       else
         R{:, k}  = fun(X, B{:, k});
       end
+      R.Properties.VariableTypes(k) = class(R{:, k});
     end
   catch
     functionName = func2str(fun);

--- a/modules/table/functions/@table/horzcat.m
+++ b/modules/table/functions/@table/horzcat.m
@@ -28,10 +28,12 @@ function T = horzcat(varargin)
       end
       out = struct(T);
       names = [T.Properties.VariableNames, T2.Properties.VariableNames];
+      types = [T.Properties.VariableTypes, T2.Properties.VariableTypes];
       if ~isAllUnique(names)
         error(_('All names must be unique.'));
       end
       out.Properties.VariableNames = names;
+      out.Properties.VariableTypes = types;
       for k = 1:length(st1.Properties.VariableNames)
         out.data.(st1.Properties.VariableNames{k}) = st1.data.(st1.Properties.VariableNames{k});
       end

--- a/modules/table/functions/@table/subsref.m
+++ b/modules/table/functions/@table/subsref.m
@@ -23,9 +23,9 @@ function R = subsref(T, sref)
       
     otherwise
       error(_('Unsupported subsref type.'));
+    end
   end
-end
-%=============================================================================
+  %=============================================================================
 function R = dotSubsref(T, sref)
   st = struct(T);
   if any(contains(st.Properties.VariableNames, 'Row'))
@@ -66,16 +66,16 @@ function R = dotSubsref(T, sref)
 end
 %=============================================================================
 function R = braceSubsref(T, sref)
-
+  
   if (length(sref(1).subs) ~= 2)
     error('Unsupported subscript type. Brace indexing requires two subscripts (row and column).');
   end
-
+  
   st = struct(T);
-
+  
   rowIdx = sref(1).subs{1};
   colSub = sref(1).subs{2};
-    
+  
   if ischar(rowIdx) || isstring(rowIdx) || iscellstr(rowIdx)
     if (isscalar(rowIdx) && rowIdx == ":")
       rowIdx = 1:height(T);
@@ -90,7 +90,7 @@ function R = braceSubsref(T, sref)
   else
     error(_('Invalid row subscript type.'));
   end
-    
+  
   if (ischar(colSub) || isstring(colSub) || iscellstr(colSub))
     if (isscalar(colSub) && colSub == ":")
       colSub = 1:width(T);
@@ -105,7 +105,7 @@ function R = braceSubsref(T, sref)
   numRows = length(rowIdx);
   numCols = length(colSub);
   R = [];
-
+  
   for i = 1:numCols
     variable = st.Properties.VariableNames{colSub(i)};
     tempdata = st.data.(variable);
@@ -170,7 +170,7 @@ function R = parentheseSubsref(T, sref)
   else
     error(_('Invalid column indexing.'));
   end
-
+  
   selectedVarNames = st.Properties.VariableNames(colIdx);
   tableData = cell(1, length(selectedVarNames));
   for i = 1:length(selectedVarNames)

--- a/modules/table/functions/@table/table.m
+++ b/modules/table/functions/@table/table.m
@@ -76,8 +76,17 @@ function varargout = table(varargin)
       end
     end
   end
-
+  T = updateVariableTypes(T);
   varargout{1} = class(T, 'table');
+end
+%=============================================================================
+function st = updateVariableTypes(st)
+  newVariableTypes = string([]);
+  for j = 1:length(st.Properties.VariableNames)
+    colName = st.Properties.VariableNames{j};
+    newVariableTypes(end + 1) = class(st.data.(colName));
+  end
+  st.Properties.VariableTypes = newVariableTypes;
 end
 %=============================================================================
 function tf = isDataArgument(name, nextIsRowNames, nextIsVariableNames)
@@ -204,6 +213,7 @@ function T = initializeTable()
   T.Version = 1;
   T.Properties = struct();
   T.Properties.VariableNames = {};
+  T.Properties.VariableTypes = string([]);
   T.Properties.RowNames = {};
 end
 %=============================================================================

--- a/modules/table/help/en_US/xml/1_accessing_manipulating_table.xml
+++ b/modules/table/help/en_US/xml/1_accessing_manipulating_table.xml
@@ -33,6 +33,11 @@
     >You can concatenate tables vertically (one below the other) using the vertcat function. This function combines tables by appending the rows of one table to the rows of another table.</p>
   <p>see examples: <b>Vertical Concatenation</b></p>
   <p />
+  <p><b>Convert variable types</b></p>
+  <p>You can convert table variables by using the <b
+      >VariableTypes</b> property.</p>
+  <p>see examples: <b>VariableTypes</b> example</p>
+  <p />
   <p><b>Summary</b></p>
   <p
     >In Nelson, tables provide a flexible way to store and manipulate heterogeneous data. You can easily insert data, extract parts of the table, and concatenate tables both horizontally and vertically using built-in functionality like dot notation and concatenation functions (horzcat, vertcat), making table manipulation intuitive and powerful for data analysis.</p>
@@ -158,6 +163,27 @@ T_vert = [T1; T3]  % or T_vert = vertcat(T1, T3)
     </example_item_data>
   </example_item>
 
+  <example_item>
+    <example_item_type>nelson</example_item_type>
+    <example_item_description>Convert variable types</example_item_description>
+    <example_item_data
+      ><![CDATA[Names = {'John'; 'Alice'; 'Bob'; 'Diana'};
+Age = [28; 34; 22; 30];
+Height = [175; 160; 180; 165];
+Weight = [70; 55; 80; 60];
+T = table(Names, Age, Height, Weight);
+T.Properties.VariableTypes
+T{:,1}
+T{:,2}
+T.Properties.VariableTypes = ["string"    "int8"    "double"    "double"];
+T{:,1}
+T{:,2}
+T.Properties.VariableTypes]]>
+    </example_item_data>
+  </example_item>
+
+
+
 </examples>
 
   <see_also>
@@ -178,6 +204,11 @@ T_vert = [T1; T3]  % or T_vert = vertcat(T1, T3)
       <history_version>1.8.0</history_version>
       <history_description>initial version</history_description>
     </history_item>
+    <history_item>
+      <history_version>1.10.0</history_version>
+      <history_description>VariableTypes property</history_description>
+    </history_item>
+
   </history>
 
   <authors>

--- a/modules/table/tests/test_table_variableTypes.m
+++ b/modules/table/tests/test_table_variableTypes.m
@@ -1,0 +1,38 @@
+%=============================================================================
+% Copyright (c) 2016-present Allan CORNET (Nelson)
+%=============================================================================
+% This file is part of the Nelson.
+%=============================================================================
+% LICENCE_BLOCK_BEGIN
+% SPDX-License-Identifier: LGPL-3.0-or-later
+% LICENCE_BLOCK_END
+%=============================================================================
+T = table();
+assert_isequal(T.Properties.VariableTypes, string([]));
+%=============================================================================
+A = 1;
+B = 2;
+T1 = table(A);
+T2 = table(B);
+T = horzcat(T1, T2);
+assert_isequal(T.Properties.VariableTypes, ["double", "double"]);
+%=============================================================================
+T1 = table(int8(1));
+T2 = table(int16(2));
+T = [T1; T2];
+assert_isequal(T.Properties.VariableTypes, ["int8"]);
+assert_isequal(class(T{:,1}), 'int8');
+T.Properties.VariableTypes = "int16";
+assert_isequal(class(T{:,1}), 'int16');
+%=============================================================================
+Names = {'John'; 'Alice'; 'Bob'; 'Diana'};
+Age = [28; 34; 22; 30];
+Height = [175; 160; 180; 165];
+Weight = [70; 55; 80; 60];
+T = table(Names, Age, Height, Weight);
+assert_isequal(T.Properties.VariableTypes, [ "cell"    "double"    "double"    "double"]);
+T.Properties.VariableTypes = ["string"    "int8"    "double"    "double"];
+assert_isequal(class(T{:,1}), 'string');
+assert_isequal(class(T{:,2}), 'int8');
+assert_isequal(T.Properties.VariableTypes, [ "string"    "int8"    "double"    "double"]);
+%=============================================================================

--- a/modules/types/src/cpp/ArrayOf_TableType.cpp
+++ b/modules/types/src/cpp/ArrayOf_TableType.cpp
@@ -12,6 +12,7 @@
 #include "Data.hpp"
 #include "Error.hpp"
 #include "i18n.hpp"
+#include "ClassName.hpp"
 //=============================================================================
 namespace Nelson {
 //=============================================================================
@@ -49,10 +50,14 @@ ArrayOf::tableConstructor(const ArrayOfVector& columnValues, const stringVector&
     ArrayOf version = ArrayOf::doubleConstructor(NLS_TABLE_VERSION);
     tableArrayOf.setField(fieldnames[1], version);
 
+    stringVector variableTypes = ClassName(columnValues);
+    Dimensions dimsVariableTypes(1, variableTypes.size());
+
     ArrayOf properties;
-    stringVector propertyNames = { "VariableNames", "RowNames" };
+    stringVector propertyNames = { "VariableNames", "VariableTypes", "RowNames" };
     ArrayOfVector propertyValues;
     propertyValues.push_back(ArrayOf::toCellArrayOfCharacterRowVectors(variableNames));
+    propertyValues.push_back(ArrayOf::stringArrayConstructor(variableTypes, dimsVariableTypes));
     propertyValues.push_back(ArrayOf::toCellArrayOfCharacterRowVectors(rowNames));
     properties = ArrayOf::structScalarConstructor(propertyNames, propertyValues);
 


### PR DESCRIPTION
- Implements VariableTypes property for table data type
- Updates table manipulation functions to handle variable types
- Adds test coverage for VariableTypes functionality
- Updates documentation with new property details
