### PR TITLE
feat(gui, config, text_editor): allow to use your prefered text editor with nelson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `urlencode`: Replace special characters in URLs with escape characters.
 - `docroot`: Utility to retrieve or define the root directory of Nelson Help.
 - `ismodule`: second input argument `isprotected` added.
+- `editor('editor_command', cmd)` allows to change text editor in Nelson (for example: VS Code)
 
 ### Changed
 

--- a/modules/gui/src/cpp/QtHistoryBrowser.cpp
+++ b/modules/gui/src/cpp/QtHistoryBrowser.cpp
@@ -78,7 +78,6 @@ QtHistoryBrowser::createContextMenu()
 
     m_toEditor = new QAction(TR("Create Script"), this);
     connect(m_toEditor, SIGNAL(triggered()), this, SLOT(toTextEditor()));
-
     m_popup->addAction(m_execute);
     m_popup->addAction(m_clearall);
     m_popup->addAction(m_copy);
@@ -94,6 +93,7 @@ QtHistoryBrowser::contextMenuEvent(QContextMenuEvent* event)
         m_toEditor->setEnabled(items.size() > 0);
         m_execute->setEnabled(items.size() > 0);
         m_copy->setEnabled(items.size() > 0);
+        m_toEditor->setVisible(NelsonConfiguration::getInstance()->useEmbeddedEditor());
         m_popup->exec(event->globalPos());
     }
 }

--- a/modules/nelson_manager/src/include/NelsonConfiguration.hpp
+++ b/modules/nelson_manager/src/include/NelsonConfiguration.hpp
@@ -222,6 +222,15 @@ public:
     std::wstring
     getDefaultLocale();
     //=============================================================================
+    bool
+    useEmbeddedEditor();
+    //=============================================================================
+    void
+    setCurrentEditor(const std::wstring& _editorCommandLine, bool save);
+    //=============================================================================
+    std::wstring
+    getCurrentEditor();
+    //=============================================================================
 private:
     NelsonConfiguration();
     //=============================================================================
@@ -276,11 +285,15 @@ private:
     //=============================================================================
     bool currentAxesOnClick = true;
     //=============================================================================
+    bool useEmbeddedEditorFlag = true;
+    bool embeddedEditorFlagLoaded = false;
+    //=============================================================================
     std::wstring websiteUrl;
     std::wstring updateUrl;
     std::wstring bugTrackerUrl;
     std::wstring docBookUrl;
     std::wstring currentLocale;
+    std::wstring editorCommandLine;
     //=============================================================================
 };
 //=============================================================================

--- a/modules/text_editor/CMakeLists.txt
+++ b/modules/text_editor/CMakeLists.txt
@@ -99,12 +99,15 @@ target_include_directories(
           ${CMAKE_CURRENT_SOURCE_DIR}/src/include
           ${CMAKE_CURRENT_SOURCE_DIR}/../interpreter/src/include
           ${CMAKE_CURRENT_SOURCE_DIR}/../types/src/include
+          ${CMAKE_CURRENT_SOURCE_DIR}/../nelson_manager/src/include
+          ${CMAKE_CURRENT_SOURCE_DIR}/../os_functions/src/include
           ${CMAKE_CURRENT_SOURCE_DIR}/../stream_manager/src/include
           ${CMAKE_CURRENT_SOURCE_DIR}/../i18n/src/include
           ${CMAKE_CURRENT_SOURCE_DIR}/../engine/src/include)
 
 target_link_libraries(${module_library_builtin_name} ${module_library_name}
-                      nlsError_manager nlsI18n nlsInterpreter nlsTypes)
+                      nlsError_manager nlsI18n nlsInterpreter nlsTypes
+                      nlsNelson_manager nlsOs_functions)
 # ==============================================================================
 endif()
 # ==============================================================================

--- a/modules/text_editor/builtin/c/nlsText_editor_builtin.vcxproj
+++ b/modules/text_editor/builtin/c/nlsText_editor_builtin.vcxproj
@@ -95,7 +95,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;NLSTEXT_EDITOR_BUILTIN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)modules/text_editor/builtin/include;$(SolutionDir)modules/text_editor/src/include;$(SolutionDir)modules/commons/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/overload/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)modules/text_editor/builtin/include;$(SolutionDir)modules/text_editor/src/include;$(SolutionDir)modules/commons/src/include;$(SolutionDir)modules/os_functions/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/overload/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)modules/nelson_manager/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost</AdditionalIncludeDirectories>
       <OpenMPSupport>true</OpenMPSupport>
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -116,7 +116,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;_USRDLL;NLSTEXT_EDITOR_BUILTIN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)modules/text_editor/builtin/include;$(SolutionDir)modules/text_editor/src/include;$(SolutionDir)modules/commons/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/overload/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)modules/text_editor/builtin/include;$(SolutionDir)modules/text_editor/src/include;$(SolutionDir)modules/commons/src/include;$(SolutionDir)modules/os_functions/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/overload/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)modules/nelson_manager/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost</AdditionalIncludeDirectories>
       <OpenMPSupport>true</OpenMPSupport>
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -139,7 +139,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NLSTEXT_EDITOR_BUILTIN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)modules/text_editor/builtin/include;$(SolutionDir)modules/text_editor/src/include;$(SolutionDir)modules/commons/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/overload/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)modules/text_editor/builtin/include;$(SolutionDir)modules/text_editor/src/include;$(SolutionDir)modules/commons/src/include;$(SolutionDir)modules/os_functions/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/overload/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)modules/nelson_manager/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost</AdditionalIncludeDirectories>
       <OpenMPSupport>true</OpenMPSupport>
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -164,7 +164,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>WIN32;NDEBUG;_WINDOWS;_USRDLL;NLSTEXT_EDITOR_BUILTIN_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>$(SolutionDir)modules/text_editor/builtin/include;$(SolutionDir)modules/text_editor/src/include;$(SolutionDir)modules/commons/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/overload/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)modules/text_editor/builtin/include;$(SolutionDir)modules/text_editor/src/include;$(SolutionDir)modules/commons/src/include;$(SolutionDir)modules/os_functions/src/include;$(SolutionDir)modules/interpreter/src/include;$(SolutionDir)modules/core/src/include;$(SolutionDir)modules/types/src/include;$(SolutionDir)modules/stream_manager/src/include;$(SolutionDir)modules/overload/src/include;$(SolutionDir)modules/i18n/src/include;$(SolutionDir)modules/engine/src/include;$(SolutionDir)modules/error_manager/src/include;$(SolutionDir)modules/nelson_manager/src/include;$(SolutionDir)../NelSon-thirdparty-$(PlatformName)/Boost</AdditionalIncludeDirectories>
       <OpenMPSupport>true</OpenMPSupport>
       <DisableSpecificWarnings>4190</DisableSpecificWarnings>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -194,6 +194,12 @@
     </ProjectReference>
     <ProjectReference Include="..\..\..\interpreter\src\c\nlsInterpreter.vcxproj">
       <Project>{17135b09-bc25-448e-9750-c09a87fde6f8}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\nelson_manager\src\c\nlsNelson_manager.vcxproj">
+      <Project>{e467b14f-0d56-4237-b649-eb5572b5e731}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\os_functions\src\c\nlsOs_functions.vcxproj">
+      <Project>{fa50a5eb-b1b3-4035-87bb-8d3124cb7c80}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\..\types\src\c\nlsTypes.vcxproj">
       <Project>{ab85e897-56b7-4792-8a8e-f3797be2b7cc}</Project>

--- a/modules/text_editor/builtin/cpp/editorBuiltin.cpp
+++ b/modules/text_editor/builtin/cpp/editorBuiltin.cpp
@@ -12,7 +12,8 @@
 #include "TextEditor.hpp"
 #include "InputOutputArgumentsCheckers.hpp"
 #include "PredefinedErrorMessages.hpp"
-
+#include "NelsonConfiguration.hpp"
+#include "SystemCommand.hpp"
 //=============================================================================
 using namespace Nelson;
 //=============================================================================
@@ -23,20 +24,49 @@ Nelson::TextEditorGateway::editorBuiltin(Evaluator* eval, int nLhs, const ArrayO
     nargoutcheck(nLhs, 0, 0);
     switch (argIn.size()) {
     case 0: {
-        textEditor(eval);
+        if (NelsonConfiguration::getInstance()->useEmbeddedEditor()) {
+            textEditor(eval);
+        } else {
+            std::wstring command;
+#ifdef _MSC_VER
+            command = L"start /b " + NelsonConfiguration::getInstance()->getCurrentEditor();
+#else
+            command = NelsonConfiguration::getInstance()->getCurrentEditor() + L" &";
+#endif
+            SystemCommand(command, 15, false, eval->getID());
+        }
     } break;
     case 1: {
         std::wstring filename = argIn[0].getContentAsWideString();
-        textEditor(eval, filename);
+        if (NelsonConfiguration::getInstance()->useEmbeddedEditor()) {
+            textEditor(eval, filename);
+        } else {
+            std::wstring command;
+#if _MSC_VER
+            command = L"start /b " + NelsonConfiguration::getInstance()->getCurrentEditor()
+                + std::wstring(L" ") + filename;
+#else
+            command
+                = NelsonConfiguration::getInstance()->getCurrentEditor() + L" " + filename + L" &";
+#endif
+            SystemCommand(command, 15, false, eval->getID());
+        }
     } break;
     case 2: {
         std::wstring option = argIn[0].getContentAsWideString();
         if (option == L"new_file") {
             if (argIn[1].isEmpty() && argIn[1].isDoubleClass()) {
-                textEditor(eval, true);
+                if (NelsonConfiguration::getInstance()->useEmbeddedEditor()) {
+                    textEditor(eval, true);
+                }
             } else {
                 Error(_W("Wrong value for #2 argument."));
             }
+        } else if (option == L"editor_command") {
+            std::wstring commandLine = argIn[1].getContentAsWideString();
+            NelsonConfiguration::getInstance()->setCurrentEditor(commandLine, true);
+        } else {
+            Error(_W("Wrong value for #1 argument."));
         }
     } break;
     default: {

--- a/modules/text_editor/help/en_US/xml/editor.xml
+++ b/modules/text_editor/help/en_US/xml/editor.xml
@@ -9,23 +9,61 @@
   <syntax>
     <syntax_item>editor()</syntax_item>
     <syntax_item>editor(filename)</syntax_item>
+    <syntax_item>editor('editor_command', cmd)</syntax_item>
+
   </syntax>
   
   <param_input>
+
     <param_input_item>
       <param_name>filename</param_name>
       <param_description>a string: filename to open.</param_description>
     </param_input_item>
 
+    <param_input_item>
+      <param_name>cmd</param_name>
+      <param_description
+      >a string representing the command to launch your preferred code editor.</param_description>
+    </param_input_item>
+
+
   </param_input>
 
   <description>
     <p><b>editor</b> opens an existing file in the nelson's editor.</p>
-    <p><b>editor</b> must be considered as internal.</p>
+    <p><b>editor</b> must be considered as internal and <b
+      >edit</b> must be preferred.</p>
+    <p>Set another text editor as default: (example with VS code)</p>
+    <p><code>editor('editor_command', 'code')</code></p>
+    <p>To restore the default editor, use:</p>
+    <p><code>editor('editor_command', '')</code></p>
+    <p
+    >Change text editor is persistent and will be saved in a configuration file.</p>
   </description>
   
   <used_function />
   <bibliography />
+
+<examples>
+  <example_item>
+    <example_item_type>nelson</example_item_type>
+    <example_item_description />
+    <example_item_data
+      ><![CDATA[edit('edit')
+if ispc()
+  editor('editor_command ', 'notepad')
+else
+  editor('editor_command ', 'vim')
+end
+edit('edit')
+% restore default editor
+editor('editor_command ', '')
+]]>
+    </example_item_data>
+  </example_item>
+
+</examples>
+
 
   <see_also>
     <see_also_item>
@@ -38,6 +76,12 @@
       <history_version>1.0.0</history_version>
       <history_description>initial version</history_description>
     </history_item>
+    <history_item>
+      <history_version>1.10.0</history_version>
+      <history_description
+      >Option to change default text editor</history_description>
+    </history_item>
+
   </history>
 
   <authors>


### PR DESCRIPTION
edit foo.m  launchs vs code if editor defined as default with editor('editor_command','code')