### PR TITLE
chore: update macos brew to latest

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,7 +7,7 @@ jobs:
   nix_build:
     name: ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -20,6 +20,11 @@ jobs:
             label: "macOS Latest"
 
     steps:
+      - name: Update Homebrew (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew upgrade
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install Nix


### PR DESCRIPTION
set timeout-minutes to 120 macos 15 build is slow (nix)
