### PR TITLE
Fix Windows build for MaxOpenedFiles

### DIFF
--- a/modules/engine/src/cpp/MaxOpenedFiles.cpp
+++ b/modules/engine/src/cpp/MaxOpenedFiles.cpp
@@ -7,7 +7,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // LICENCE_BLOCK_END
 //=============================================================================
-#if defined(__APPLE__) || defined(__MACH__)
+#if (defined(__APPLE__) || defined(__MACH__)) && !defined(_WIN32)
+#define NELSON_SET_MAX_OPENED_FILES
 #define _DARWIN_UNLIMITED_STREAMS
 #include <sys/resource.h>
 #endif
@@ -18,7 +19,7 @@ namespace Nelson {
 bool
 setMaxOpenedFiles()
 {
-#if defined(__APPLE__) || defined(__MACH__)
+#if defined(NELSON_SET_MAX_OPENED_FILES)
     // Set maximum number of open file descriptors
     struct rlimit maxfds, newfds;
     // Due to bugs in OS X (<rdar://problem/2941095>, <rdar://problem/3342704>,


### PR DESCRIPTION
## Summary
- Guard the macOS `sys/resource.h` include and `getrlimit`/`setrlimit` implementation behind a shared platform macro.
- Explicitly exclude `_WIN32` so MSVC cannot enter the POSIX resource-limit code path even if Apple/Mach macros are present in the build environment.

## Context
Windows CI failed with:

```text
modules\engine\src\cpp\MaxOpenedFiles.cpp(14,10): error C1083: Cannot open include file: 'sys/resource.h': No such file or directory
```

## Testing
- Not run locally; repository checkout was not available in the local workspace. Change is limited to preprocessor guards around platform-specific code.